### PR TITLE
Pin dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ poetry self add poetry-plugin-dotenv
 poetry install
 ```
 
-To add new dependancies in this project, run `poetry add <dependency_name>`.
+To add new dependencies in this project, run `poetry add <dependency_name>`.
 
 Install pre-commit hooks, to automatically execute code checks and formatting tools before each commit as shown below.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "devDependencies": {
         "prettier": "3.3.3",
-        "prettier-plugin-jinja-template": "^1.4.1"
+        "prettier-plugin-jinja-template": "1.5.0"
       }
     },
     "node_modules/prettier": {
@@ -25,10 +25,11 @@
       }
     },
     "node_modules/prettier-plugin-jinja-template": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-jinja-template/-/prettier-plugin-jinja-template-1.4.1.tgz",
-      "integrity": "sha512-YHDa/f9BpEDIYIPKsnmoKQudWszXBPaVifjR7X+W2n/uAzWLXV/j9FEvua3np7gkzSEOFyapJQrCS4YhhbhbdA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-jinja-template/-/prettier-plugin-jinja-template-1.5.0.tgz",
+      "integrity": "sha512-gLOnCmM8j/psoO+s1L/M3chKmZEO7zrqhodbD+xRONrmOaYhU7Y9gLxlTVm++MeuRt3hA0jev6TmIlNFcr2hYA==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "prettier": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
     "prettier": "3.3.3",
-    "prettier-plugin-jinja-template": "^1.4.1"
+    "prettier-plugin-jinja-template": "1.5.0"
   }
 }


### PR DESCRIPTION
### What is the context of this PR?

Fixes: [ONSDESYS-651](https://officefornationalstatistics.atlassian.net/browse/ONSDESYS-651)

This PR pins all the JS dependencies after the recent issue with npm packages being compromised (https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised). This is to protect us from any issues if this happens again.

### How to review this PR

- Spin up the repo and check that it still works as expected
- Run `npm ls` on the main branch and make sure the versions listed match the ones in this PR
