### PR TITLE
Fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/application.py
+++ b/application.py
@@ -40,6 +40,9 @@ def component(component_name):
         requested_directory = os.path.normpath(
             os.path.join(root_directory, component_name)
         )
+        # Make sure requested_directory is inside root_directory
+        if not requested_directory.startswith(root_directory):
+            raise ValueError("Invalid component name or path.")
         example_files = [
             file
             for file in os.listdir(requested_directory)
@@ -52,8 +55,6 @@ def component(component_name):
         )
     except FileNotFoundError:
         return "Component not found", 404
-    except ValueError:
-        return "Invalid component name or path.", 400
 
 
 @app.route("/components/<component_name>/<filename>")
@@ -62,6 +63,9 @@ def example(component_name, filename):
         requested_path = os.path.normpath(
             os.path.join(root_directory, component_name, filename)
         )
+        # Make sure requested_path is inside root_directory
+        if not requested_path.startswith(root_directory):
+            raise ValueError("Invalid component name or path.")
         with open(requested_path, "r") as content:
             content = frontmatter.load(content)
         if "layout" in content.metadata:
@@ -76,8 +80,6 @@ def example(component_name, filename):
         return render_template_string(template)
     except FileNotFoundError:
         return "File not found", 404
-    except ValueError:
-        return "Invalid component name or path.", 400
 
 
 if __name__ == "__main__":

--- a/application.py
+++ b/application.py
@@ -5,6 +5,7 @@ from flask import Flask, render_template, render_template_string, send_from_dire
 from jinja2 import ChainableUndefined
 
 app = Flask(__name__)
+root_directory = os.path.abspath("templates/components")
 
 
 def setAttributes(dictionary, attributes):
@@ -24,7 +25,6 @@ def generate_images(filename):
 
 @app.route("/")
 def index():
-    root_directory = "templates/components"
     directories = {
         directory
         for directory in os.listdir(root_directory)
@@ -37,7 +37,6 @@ def index():
 @app.route("/components/<component_name>")
 def component(component_name):
     try:
-        root_directory = os.path.abspath("templates/components")
         requested_directory = os.path.normpath(
             os.path.join(root_directory, component_name)
         )
@@ -61,7 +60,6 @@ def component(component_name):
 @app.route("/components/<component_name>/<filename>")
 def example(component_name, filename):
     try:
-        root_directory = os.path.abspath("templates/components")
         requested_path = os.path.normpath(
             os.path.join(root_directory, component_name, filename)
         )

--- a/application.py
+++ b/application.py
@@ -42,9 +42,7 @@ def component(component_name):
     if not requested_directory.startswith(root_directory):
         return "Invalid component name", 400
     example_files = [
-        file
-        for file in os.listdir(requested_directory)
-        if file.startswith("example")
+        file for file in os.listdir(requested_directory) if file.startswith("example")
     ]
     return render_template(
         "component-examples-list.html",
@@ -56,11 +54,9 @@ def component(component_name):
 @app.route("/components/<component_name>/<filename>")
 def example(component_name, filename):
     try:
-        base_path = os.path.abspath(os.path.join("templates", "components"))
-        requested_path = os.path.abspath(os.path.normpath(os.path.join(base_path, component_name, filename)))
-        if not requested_path.startswith(base_path + os.sep):
-            # Attempt to escape base_path – forbidden
-            return "File not found"
+        requested_path = os.path.abspath(
+            os.path.join("templates", "components", component_name, filename)
+        )
         with open(requested_path, "r") as content:
             content = frontmatter.load(content)
         if "layout" in content.metadata:

--- a/application.py
+++ b/application.py
@@ -37,7 +37,9 @@ def index():
 @app.route("/components/<component_name>")
 def component(component_name):
     try:
-        requested_directory = os.path.join(root_directory, component_name)
+        requested_directory = os.path.normpath(
+            os.path.join(root_directory, component_name)
+        )
         # Make sure requested_directory is inside root_directory
         if not requested_directory.startswith(root_directory):
             raise ValueError("Invalid component name or path.")
@@ -58,7 +60,9 @@ def component(component_name):
 @app.route("/components/<component_name>/<filename>")
 def example(component_name, filename):
     try:
-        requested_path = os.path.join(root_directory, component_name, filename)
+        requested_path = os.path.normpath(
+            os.path.join(root_directory, component_name, filename)
+        )
         # Make sure requested_path is inside root_directory
         if not requested_path.startswith(root_directory):
             raise ValueError("Invalid component name or path.")

--- a/application.py
+++ b/application.py
@@ -37,9 +37,7 @@ def index():
 @app.route("/components/<component_name>")
 def component(component_name):
     try:
-        requested_directory = os.path.normpath(
-            os.path.join(root_directory, component_name)
-        )
+        requested_directory = os.path.join(root_directory, component_name)
         # Make sure requested_directory is inside root_directory
         if not requested_directory.startswith(root_directory):
             raise ValueError("Invalid component name or path.")
@@ -60,9 +58,7 @@ def component(component_name):
 @app.route("/components/<component_name>/<filename>")
 def example(component_name, filename):
     try:
-        requested_path = os.path.normpath(
-            os.path.join(root_directory, component_name, filename)
-        )
+        requested_path = os.path.join(root_directory, component_name, filename)
         # Make sure requested_path is inside root_directory
         if not requested_path.startswith(root_directory):
             raise ValueError("Invalid component name or path.")

--- a/application.py
+++ b/application.py
@@ -40,9 +40,6 @@ def component(component_name):
         requested_directory = os.path.normpath(
             os.path.join(root_directory, component_name)
         )
-        # Make sure requested_directory is inside root_directory
-        if not requested_directory.startswith(root_directory):
-            raise ValueError("Invalid component name or path.")
         example_files = [
             file
             for file in os.listdir(requested_directory)
@@ -55,6 +52,8 @@ def component(component_name):
         )
     except FileNotFoundError:
         return "Component not found", 404
+    except ValueError:
+        return "Invalid component name or path.", 400
 
 
 @app.route("/components/<component_name>/<filename>")
@@ -63,9 +62,6 @@ def example(component_name, filename):
         requested_path = os.path.normpath(
             os.path.join(root_directory, component_name, filename)
         )
-        # Make sure requested_path is inside root_directory
-        if not requested_path.startswith(root_directory):
-            raise ValueError("Invalid component name or path.")
         with open(requested_path, "r") as content:
             content = frontmatter.load(content)
         if "layout" in content.metadata:
@@ -80,6 +76,8 @@ def example(component_name, filename):
         return render_template_string(template)
     except FileNotFoundError:
         return "File not found", 404
+    except ValueError:
+        return "Invalid component name or path.", 400
 
 
 if __name__ == "__main__":

--- a/application.py
+++ b/application.py
@@ -51,7 +51,12 @@ def component(component_name):
 @app.route("/components/<component_name>/<filename>")
 def example(component_name, filename):
     try:
-        with open(f"templates/components/{component_name}/{filename}", "r") as content:
+        base_path = os.path.abspath(os.path.join("templates", "components"))
+        requested_path = os.path.abspath(os.path.normpath(os.path.join(base_path, component_name, filename)))
+        if not requested_path.startswith(base_path + os.sep):
+            # Attempt to escape base_path – forbidden
+            return "File not found"
+        with open(requested_path, "r") as content:
             content = frontmatter.load(content)
         if "layout" in content.metadata:
             template = content.content

--- a/application.py
+++ b/application.py
@@ -36,27 +36,38 @@ def index():
 
 @app.route("/components/<component_name>")
 def component(component_name):
-    root_directory = os.path.abspath("templates/components")
-    requested_directory = os.path.normpath(os.path.join(root_directory, component_name))
-    # Make sure requested_directory is inside root_directory
-    if not requested_directory.startswith(root_directory):
-        return "Invalid component name", 400
-    example_files = [
-        file for file in os.listdir(requested_directory) if file.startswith("example")
-    ]
-    return render_template(
-        "component-examples-list.html",
-        example_files=sorted(example_files),
-        component_name=component_name,
-    )
+    try:
+        root_directory = os.path.abspath("templates/components")
+        requested_directory = os.path.normpath(
+            os.path.join(root_directory, component_name)
+        )
+        # Make sure requested_directory is inside root_directory
+        if not requested_directory.startswith(root_directory):
+            raise ValueError("Invalid component name or path.")
+        example_files = [
+            file
+            for file in os.listdir(requested_directory)
+            if file.startswith("example")
+        ]
+        return render_template(
+            "component-examples-list.html",
+            example_files=sorted(example_files),
+            component_name=component_name,
+        )
+    except FileNotFoundError:
+        return "Component not found", 404
 
 
 @app.route("/components/<component_name>/<filename>")
 def example(component_name, filename):
     try:
-        requested_path = os.path.abspath(
-            os.path.join("templates", "components", component_name, filename)
+        root_directory = os.path.abspath("templates/components")
+        requested_path = os.path.normpath(
+            os.path.join(root_directory, component_name, filename)
         )
+        # Make sure requested_path is inside root_directory
+        if not requested_path.startswith(root_directory):
+            raise ValueError("Invalid component name or path.")
         with open(requested_path, "r") as content:
             content = frontmatter.load(content)
         if "layout" in content.metadata:
@@ -70,7 +81,7 @@ def example(component_name, filename):
             )
         return render_template_string(template)
     except FileNotFoundError:
-        return "File not found"
+        return "File not found", 404
 
 
 if __name__ == "__main__":

--- a/application.py
+++ b/application.py
@@ -30,8 +30,8 @@ def resolvePath(path):
 
     resolved = os.path.normpath(os.path.join(root_directory, path))
 
-    # Ensure the path is inside the allowed root (prevents ../ traversal)
-    if not resolved.startswith(root_directory + os.sep) and resolved != root_directory:
+    # Ensure the path is inside the allowed root (prevents ../ traversal), using commonpath for robustness
+    if os.path.commonpath([root_directory, resolved]) != root_directory:
         abort(404)
 
     # If the path doesn't exist, return 404

--- a/application.py
+++ b/application.py
@@ -1,7 +1,13 @@
 import os
 
 import frontmatter
-from flask import Flask, render_template, render_template_string, send_from_directory
+from flask import (
+    Flask,
+    abort,
+    render_template,
+    render_template_string,
+    send_from_directory,
+)
 from jinja2 import ChainableUndefined
 
 app = Flask(__name__)
@@ -12,6 +18,27 @@ def setAttributes(dictionary, attributes):
     for key in attributes:
         dictionary[key] = attributes[key]
     return dictionary
+
+
+def resolvePath(path):
+    """
+    Resolve a path inside `templates/components` safely.
+
+    - Prevents path traversal by ensuring the resolved path is under `root_directory`.
+    - Returns a filesystem path if it exists; otherwise triggers a 404.
+    """
+
+    resolved = os.path.normpath(os.path.join(root_directory, path))
+
+    # Ensure the path is inside the allowed root (prevents ../ traversal)
+    if not resolved.startswith(root_directory + os.sep) and resolved != root_directory:
+        abort(404)
+
+    # If the path doesn't exist, return 404
+    if not os.path.exists(resolved):
+        abort(404)
+
+    return resolved
 
 
 app.jinja_env.filters["setAttributes"] = setAttributes
@@ -36,50 +63,35 @@ def index():
 
 @app.route("/components/<component_name>")
 def component(component_name):
-    try:
-        requested_directory = os.path.normpath(
-            os.path.join(root_directory, component_name)
-        )
-        # Make sure requested_directory is inside root_directory
-        if not requested_directory.startswith(root_directory):
-            raise ValueError("Invalid component name or path.")
-        example_files = [
-            file
-            for file in os.listdir(requested_directory)
-            if file.startswith("example")
-        ]
-        return render_template(
-            "component-examples-list.html",
-            example_files=sorted(example_files),
-            component_name=component_name,
-        )
-    except FileNotFoundError:
-        return "Component not found", 404
+
+    dir = resolvePath(component_name)
+
+    example_files = [file for file in os.listdir(dir) if file.startswith("example")]
+
+    return render_template(
+        "component-examples-list.html",
+        example_files=sorted(example_files),
+        component_name=component_name,
+    )
 
 
 @app.route("/components/<component_name>/<filename>")
 def example(component_name, filename):
-    try:
-        requested_path = os.path.normpath(
-            os.path.join(root_directory, component_name, filename)
+
+    file = resolvePath(os.path.join(component_name, filename))
+
+    with open(file, "r") as content:
+        content = frontmatter.load(content)
+    if "layout" in content.metadata:
+        template = content.content
+    else:
+        template = (
+            "{% extends 'layout/_template.njk' %}"
+            + "{% block body %}<div class='ons-u-p-m'>"
+            + content.content
+            + "</div>{% endblock %}"
         )
-        # Make sure requested_path is inside root_directory
-        if not requested_path.startswith(root_directory):
-            raise ValueError("Invalid component name or path.")
-        with open(requested_path, "r") as content:
-            content = frontmatter.load(content)
-        if "layout" in content.metadata:
-            template = content.content
-        else:
-            template = (
-                "{% extends 'layout/_template.njk' %}"
-                + "{% block body %}<div class='ons-u-p-m'>"
-                + content.content
-                + "</div>{% endblock %}"
-            )
-        return render_template_string(template)
-    except FileNotFoundError:
-        return "File not found", 404
+    return render_template_string(template)
 
 
 if __name__ == "__main__":

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/design-system-python-flask-demo/security/code-scanning/3](https://github.com/ONSdigital/design-system-python-flask-demo/security/code-scanning/3)

The best way to fix this problem is to validate and restrict the `component_name` and `filename` variables before using them in filesystem operations. This can be done by constructing the target file path with `os.path.join`, normalizing it with `os.path.normpath`, and ensuring that the result is still within the designated base directory (`templates/components`). If the normalized path escapes this base directory, deny the request or return a "not found"/forbidden error. 

Specifically, in the `example` view in `application.py`, replace the unsafe path construction on line 54 with a secure method:
- Set a `base_path` variable to the absolute path of `templates/components`.
- Join it with `component_name` and `filename`, then use `os.path.normpath`.
- Check that the resulting path starts with the expected base directory.
- Only then open the file.

You will need to import `abort` from `flask` (which is already imported), and utilize `os.path.abspath`/`os.path.normpath` for safe path manipulations. No additional libraries are needed, as all the required functionality is in the Python standard library and Flask.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._



__Sri's Comment__: **I am able to run locally with the applied changes** 
