### PR TITLE
Fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/application.py
+++ b/application.py
@@ -36,9 +36,14 @@ def index():
 
 @app.route("/components/<component_name>")
 def component(component_name):
+    root_directory = os.path.abspath("templates/components")
+    requested_directory = os.path.normpath(os.path.join(root_directory, component_name))
+    # Make sure requested_directory is inside root_directory
+    if not requested_directory.startswith(root_directory):
+        return "Invalid component name", 400
     example_files = [
         file
-        for file in os.listdir(f"templates/components/{component_name}/")
+        for file in os.listdir(requested_directory)
         if file.startswith("example")
     ]
     return render_template(


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/design-system-python-flask-demo/security/code-scanning/2](https://github.com/ONSdigital/design-system-python-flask-demo/security/code-scanning/2)

The best fix is to ensure that the constructed path (using `component_name`) remains within a safe root directory. The process is as follows:

1. Use `os.path.join` to construct the path from the root (`templates/components`) and the user input (`component_name`).
2. Normalize the resulting path using `os.path.normpath` to eradicate `..` segments.
3. Check that the normalized path begins with the intended root directory (using `os.path.abspath` on both for full comparison).
4. Only proceed to list the directory if this check passes; otherwise, abort or return an error.

Changes required:
- In the `component` view (lines 39-43), replace the direct format-string construction of the directory path with the safe, verified approach as above.
- No new imports are needed (using only built-in `os.path`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

__Sri's Comment__: **I am able to run locally with the applied changes** 
